### PR TITLE
add uuid

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,8 +7,17 @@ edition = "2021"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+
 thiserror = "1.0.0"
 reqwest = "0.11.0"
 rand = "0.8.4"
 regex = "1.5.4"
 percent-encoding = "2.3.0"
+
+[dependencies.uuid]
+version = "1.4.0"
+features = [
+    "v4",                
+    "fast-rng",          
+    "macro-diagnostics",
+]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,3 +3,4 @@ pub mod async_tools;
 pub mod errors;
 pub mod http;
 pub mod json;
+pub mod uuid;

--- a/utils/src/uuid.rs
+++ b/utils/src/uuid.rs
@@ -1,0 +1,98 @@
+//!
+//! ```md
+//!  _   _ _   _ ___ ____  
+//! | | | | | | |_ _|  _ \
+//! | | | | | | || || | | |
+//! | |_| | |_| || || |_| |
+//!  \___/ \___/|___|____/
+//! ```
+//!
+//! # UUID
+//!
+//! This module provides ways to generate and validate UUIDs.
+//! Module includes:
+//! - UUID Type
+//! - Generate a UUID
+//! - Validate a UUID
+//! - UUID Generate Macro
+//!
+//! ## UUID Type
+//! A UUID is a 36 character string
+//! and is in the format of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//!
+//! ## Generate a UUID
+//! ```
+//! use utils::uuid;
+//! let uuid = uuid::generate();
+//! assert!(uuid.len() > 0);
+//! assert!(uuid::is_valid(&uuid));
+//! ```
+//!
+//! ## Validate a UUID
+//! ```
+//! use utils::uuid;
+//! assert!(uuid::is_valid("00000000-0000-0000-0000-000000000000"));
+//! assert!(!uuid::is_valid("00000000-0000-0000-0000-00000000000"));
+//! ```
+//!
+//! ## UUID Generate Macro
+//! ```
+//! use utils::uuid;
+//! let uuid = uuid!();
+//! assert!(uuid.len() > 0);
+//! assert!(uuid::is_valid(&uuid));
+//! ```
+
+use uuid::Uuid;
+
+/// A UUID is a 36 character string
+/// and is in the format of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+pub type UUID = Box<str>;
+
+/// Generate a new UUID
+///
+/// # Example
+/// ```
+/// use utils::uuid;
+///
+/// let uuid = uuid!();
+/// assert!(uuid.len() > 0);
+/// assert!(uuid::is_valid(&uuid));
+/// ```
+#[macro_export]
+macro_rules! uuid {
+    () => {
+        $crate::uuid::generate()
+    };
+}
+
+/// Generates a new UUID
+///
+/// # Example
+/// ```
+/// use utils::uuid;
+///
+/// let uuid = uuid::generate();
+/// assert!(uuid.len() > 0);
+/// assert!(uuid::is_valid(&uuid));
+/// ```
+pub fn generate() -> Box<str> {
+    let uuid = Uuid::new_v4();
+    uuid.to_string().as_str().into()
+}
+
+/// Checks if a given string is a valid UUID
+///
+/// A UUID is valid if it is a 36 character string
+/// and is in the format of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+///
+/// # Example
+/// ```
+/// use utils::uuid;
+///
+/// assert!(uuid::is_valid("00000000-0000-0000-0000-000000000000"));
+/// assert!(!uuid::is_valid("00000000-0000-0000-0000-00000000000"));
+/// ```
+pub fn is_valid(uuid: &str) -> bool {
+    Uuid::parse_str(uuid).is_ok()
+}


### PR DESCRIPTION
### What
- Add uuid module to utils crate
- Modules implements `generate()`, `is_valid()` and `uuid!()`
  - `generate()` and `uuid!()` create a new uuid in the format of `00000000-0000-0000-0000-000000000000`
  - `is_valid()` checks if a given string is a valid uuid
- Module also adds the `UUID` trait which represents a boxed str

### Why
- So we can use UUIDs as identifiers throughout our code

### Testing
- N/A, added doc testing